### PR TITLE
log rotation is handled at reading time, and imply that reading is re…

### DIFF
--- a/src/main/java/prometheus/exporter/jgc/parser/GCEventHandlerManager.java
+++ b/src/main/java/prometheus/exporter/jgc/parser/GCEventHandlerManager.java
@@ -47,13 +47,6 @@ public class GCEventHandlerManager implements TailerListener {
     }
 
     @Override
-    public void onRotate(File file) {
-        // not clean metric
-        registry.remove(file);
-        LOG.info("Rotate file: {}", file);
-    }
-
-    @Override
     public void onRead(File file, String line) {
         LOG.debug("Tailing file: {} >>> {}", file, line);
         registry.computeIfPresent(file, (f, handler) -> handler.consume(line));

--- a/src/main/java/prometheus/exporter/jgc/tailer/TailerListener.java
+++ b/src/main/java/prometheus/exporter/jgc/tailer/TailerListener.java
@@ -22,7 +22,5 @@ public interface TailerListener {
 
     void onClose(File file);
 
-    void onRotate(File file);
-
     void onRead(File file, String line);
 }

--- a/src/main/java/prometheus/exporter/jgc/tailer/TailerManager.java
+++ b/src/main/java/prometheus/exporter/jgc/tailer/TailerManager.java
@@ -105,12 +105,6 @@ public class TailerManager {
                         } finally {
                             iterator.remove();
                         }
-                    } else if (tailer.rotated()) {
-                        try {
-                            rotate(tailer);
-                        } finally {
-                            iterator.remove();
-                        }
                     }
                 }
 
@@ -147,18 +141,6 @@ public class TailerManager {
                 listener.onClose(tailer.getFile());
             } catch (Throwable t) {
                 LOG.error("Close file failed: {}", tailer, t);
-            }
-        }
-    }
-
-    private void rotate(Tailer tailer) {
-        try {
-            tailer.close();
-        } finally {
-            try {
-                listener.onRotate(tailer.getFile());
-            } catch (Throwable t) {
-                LOG.error("Rotate file failed: {}", tailer, t);
             }
         }
     }

--- a/src/main/java/prometheus/exporter/jgc/tailer/WindowsTailer.java
+++ b/src/main/java/prometheus/exporter/jgc/tailer/WindowsTailer.java
@@ -19,11 +19,8 @@ import java.io.File;
 import java.io.IOException;
 import java.io.RandomAccessFile;
 import java.util.List;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class WindowsTailer extends Tailer {
-    private static final Logger LOG = LoggerFactory.getLogger(WindowsTailer.class);
     private long filePointer;
 
     public WindowsTailer(
@@ -40,19 +37,6 @@ public class WindowsTailer extends Tailer {
         } finally {
             releaseFile();
         }
-    }
-
-    @Override
-    public boolean rotated() {
-        try {
-            holdFile();
-            return super.rotated();
-        } catch (IOException ex) {
-            LOG.error("IO error: {}", this.file, ex);
-        } finally {
-            releaseFile();
-        }
-        return false;
     }
 
     private void releaseFile() {

--- a/src/test/java/prometheus/exporter/jgc/tailer/TailerTest.java
+++ b/src/test/java/prometheus/exporter/jgc/tailer/TailerTest.java
@@ -177,84 +177,12 @@ public class TailerTest {
                             }
 
                             @Override
-                            public void onRotate(File file) {}
-
-                            @Override
                             public void onRead(File file, String line) {}
                         });
 
         open.await();
         manager.close();
         close.await();
-    }
-
-    @Test
-    public void testChange() throws Exception {
-        if (OperatingSystem.isWindows()) {
-            return;
-        }
-
-        File tmpdir = new File(System.getProperty("java.io.tmpdir"), "jgc");
-        tmpdir.delete();
-        tmpdir.mkdir();
-
-        File file = File.createTempFile("test-rotate", ".log", tmpdir);
-        file.deleteOnExit();
-        Tailer tailer =
-                TailerManager.newTailer(
-                        file,
-                        true,
-                        Config.DEFAULT_BATCH_SIZE,
-                        Config.DEFAULT_BUFFER_SIZE,
-                        Config.DEFAULT_LINES_PER_SECOND);
-
-        Assert.assertFalse(tailer.rotated());
-        File oldFile = new File(file.getAbsolutePath() + ".old");
-        oldFile.deleteOnExit();
-        Assert.assertTrue(file.renameTo(oldFile));
-        Assert.assertTrue(file.createNewFile());
-        Assert.assertTrue(tailer.rotated());
-    }
-
-    @Test
-    public void testTruncate() throws Exception {
-
-        File tmpdir = new File(System.getProperty("java.io.tmpdir"), "jgc");
-        tmpdir.delete();
-        tmpdir.mkdir();
-
-        File file = File.createTempFile("test-rotate", ".log", tmpdir);
-        file.deleteOnExit();
-        Tailer tailer =
-                TailerManager.newTailer(
-                        file,
-                        true,
-                        Config.DEFAULT_BATCH_SIZE,
-                        Config.DEFAULT_BUFFER_SIZE,
-                        Config.DEFAULT_LINES_PER_SECOND);
-
-        Assert.assertEquals(tailer.rotated(), false);
-
-        try (PrintWriter pw =
-                new PrintWriter(new OutputStreamWriter(new FileOutputStream(file, false)))) {
-            for (int i = 0; i < 10; ++i) {
-                pw.println("line:" + i);
-            }
-        }
-
-        while (!tailer.readLines().isEmpty())
-            ;
-
-        Assert.assertEquals(tailer.rotated(), false);
-
-        try (PrintWriter pw =
-                new PrintWriter(new OutputStreamWriter(new FileOutputStream(file, false)))) {
-            for (int i = 0; i < 5; ++i) {
-                pw.println("line:" + i);
-            }
-        }
-
-        Assert.assertEquals(tailer.rotated(), true);
     }
 
     @Test(timeout = 15000)
@@ -293,9 +221,6 @@ public class TailerTest {
                             public void onClose(File file) {
                                 close.countDown();
                             }
-
-                            @Override
-                            public void onRotate(File file) {}
 
                             @Override
                             public void onRead(File file, String line) {}


### PR DESCRIPTION
…sume at the begening of the file.

see #122 :

> So my question is, why do we want to close file when rotated ?
> No matter if inode changes or if file is truncated, I think we must reset the "raf" to the begining of the file, and keep doing next readings normally.
> Moreover,
> 
> there is no chance that gc type has changed (G1, ZGC, Classic...) during rotation.
> if logs are truncated in a middle of an "event", re using the same "diary" will allow to get the complete event to be treated by GCToolkit. (maybe?)

Now that the code is done, I'm wondering if this will work with inode change in linux? does the RAF will work even if this is an other file than previously? (i'm not able to test it I'm on windows).
An other solution, which is less elegant to me, is to not use "this" when attaching a value to a metric, because "this" can change, but use path and host to have a waranty about uniqueness. this ensure that no new metric with same dimension can be created.

I'm waiting on your comment before continuing.